### PR TITLE
Use groovy to relax type checking since type changed for 1.11

### DIFF
--- a/src/main/groovy/com/eriwen/gradle/css/source/internal/InternalGradle.groovy
+++ b/src/main/groovy/com/eriwen/gradle/css/source/internal/InternalGradle.groovy
@@ -15,6 +15,6 @@ public abstract class InternalGradle {
    }
 
    public static FileResolver toFileResolver(Project project) {
-      return project.gradle.fileResolver
+      return project.fileResolver
    }
 }


### PR DESCRIPTION
Should fix issue #22

I have only tested on gradle 1.11 but eyeballing gradle 1.8 looked like it would work too.  The issue is caused by a type change, in 1.8 getServices() returns a ServiceRegistryFactory() while in 1.11 it returns a ServiceRegistry(), moving this file to groovy for its dynamic typing smooths over the issue.
