### PR TITLE
#29 The plugin shouldn't add Maven Central to the project's repositories

### DIFF
--- a/src/main/groovy/com/eriwen/gradle/css/CssPlugin.groovy
+++ b/src/main/groovy/com/eriwen/gradle/css/CssPlugin.groovy
@@ -56,9 +56,6 @@ class CssPlugin implements Plugin<Project> {
         project.configurations {
             rhino
         }
-        project.repositories {
-            mavenCentral()
-        }
         project.dependencies {
             rhino 'org.mozilla:rhino:1.7R3'
         }


### PR DESCRIPTION
CssPlugin.groovy doesn't configure mavenCentral() for the project.