### PR TITLE
Added spaces to the operators for CSS calc functions after CSS compression

### DIFF
--- a/src/main/groovy/com/eriwen/gradle/css/CssMinifier.groovy
+++ b/src/main/groovy/com/eriwen/gradle/css/CssMinifier.groovy
@@ -50,8 +50,8 @@ class CssMinifier {
      */
     private void fixCalcFunc(File file) {
         String text = file.text
-        file.withWriter { w ->
-            w << addSpacesToOperatorsInCalcFunc(text)
+        file.withWriter(CHARSET) { writer ->
+            writer << addSpacesToOperatorsInCalcFunc(text)
         }
     }
 
@@ -61,20 +61,20 @@ class CssMinifier {
      * @return Result
      */
     private String addSpacesToOperatorsInCalcFunc(String string) {
-        StringBuffer sb = new StringBuffer()
-        Pattern p = ~/calc\([^\)]*\)/
-        Matcher m = p.matcher(string)
-        while (m.find()) {
-            String s = m.group()
+        StringBuffer stringBuffer = new StringBuffer()
+        Pattern pattern = ~/calc\([^\)]*\)/
+        Matcher matcher = pattern.matcher(string)
+        while (matcher.find()) {
+            String calcStr = matcher.group()
 
-            s = s.replaceAll("(?<=[%|px|em|rem|vw|\\d]+)\\+", " + ")
-            s = s.replaceAll("(?<=[%|px|em|rem|vw|\\d]+)\\-", " - ")
-            s = s.replaceAll("(?<=[%|px|em|rem|vw|\\d]+)\\*", " * ")
-            s = s.replaceAll("(?<=[%|px|em|rem|vw|\\d]+)\\/", " / ")
+            calcStr = calcStr.replaceAll(~/(?<=[%|px|em|rem|vw|\d]+)\+/, " + ")
+            calcStr = calcStr.replaceAll(~/(?<=[%|px|em|rem|vw|\d]+)-/ , " - ")
+            calcStr = calcStr.replaceAll(~/(?<=[%|px|em|rem|vw|\d]+)\*/, " * ")
+            calcStr = calcStr.replaceAll(~/(?<=[%|px|em|rem|vw|\d]+)\//, " / ")
 
-            m.appendReplacement(sb, s)
+            matcher.appendReplacement(stringBuffer, calcStr)
         }
-        m.appendTail(sb)
-        sb.toString()
+        matcher.appendTail(stringBuffer)
+        stringBuffer.toString()
     }
 }

--- a/src/main/groovy/com/eriwen/gradle/css/CssMinifier.groovy
+++ b/src/main/groovy/com/eriwen/gradle/css/CssMinifier.groovy
@@ -2,6 +2,8 @@ package com.eriwen.gradle.css
 
 import com.yahoo.platform.yui.compressor.CssCompressor
 
+import java.util.regex.Matcher
+import java.util.regex.Pattern
 /**
  * Utility class that houses minification logic.
  *
@@ -38,5 +40,41 @@ class CssMinifier {
                 writer.close()
             }
         }
+
+        fixCalcFunc(outputFile)
+    }
+
+    /**
+     * Fix issues related to calc function that came after CSS compression
+     * @param file File where function calc shall be fixed
+     */
+    private void fixCalcFunc(File file) {
+        String text = file.text
+        file.withWriter { w ->
+            w << addSpacesToOperatorsInCalcFunc(text)
+        }
+    }
+
+    /**
+     * Adds spaces to the operators for CSS calc functions
+     * @param string Input string
+     * @return Result
+     */
+    private String addSpacesToOperatorsInCalcFunc(String string) {
+        StringBuffer sb = new StringBuffer()
+        Pattern p = ~/calc\([^\)]*\)/
+        Matcher m = p.matcher(string)
+        while (m.find()) {
+            String s = m.group()
+
+            s = s.replaceAll("(?<=[%|px|em|rem|vw|\\d]+)\\+", " + ")
+            s = s.replaceAll("(?<=[%|px|em|rem|vw|\\d]+)\\-", " - ")
+            s = s.replaceAll("(?<=[%|px|em|rem|vw|\\d]+)\\*", " * ")
+            s = s.replaceAll("(?<=[%|px|em|rem|vw|\\d]+)\\/", " / ")
+
+            m.appendReplacement(sb, s)
+        }
+        m.appendTail(sb)
+        sb.toString()
     }
 }

--- a/src/test/groovy/com/eriwen/gradle/css/CssPluginFunctionalTest.groovy
+++ b/src/test/groovy/com/eriwen/gradle/css/CssPluginFunctionalTest.groovy
@@ -29,7 +29,7 @@ class CssPluginFunctionalTest extends FunctionalSpec {
         and:
         tempProjectDir.newFolder('src', 'custom', 'css')
         tempProjectDir.newFile("src/custom/css/file1.css") << "#id1 { color: green; }"
-        tempProjectDir.newFile("src/custom/css/file2.css") << ".class1 { color: red; }"
+        tempProjectDir.newFile("src/custom/css/file2.css") << ".class1 { color: red; width: calc(90% + 50px); }"
 
         when:
         BuildResult result = build('minifyCss')
@@ -38,7 +38,7 @@ class CssPluginFunctionalTest extends FunctionalSpec {
         File minifiedCss = new File(projectDir, 'build/all-min.css')
         minifiedCss.exists()
         minifiedCss.text.indexOf('#id1{color:green}') > -1
-        minifiedCss.text.indexOf('.class1{color:red}') > -1
+        minifiedCss.text.indexOf('.class1{color:red;width:calc(90% + 50px)}') > -1
 
         and:
         result.task(':combineCss').outcome == TaskOutcome.SUCCESS


### PR DESCRIPTION
Hi,
YUI Compressor incorrectly compresses 'calc' function in css. This issue has been fixed but YUI lib is no longer actively maintained. The last released version (2.4.8) doesn't contain objective decisions for this issue.<br>
It's additional processing for 'minifyCss' task which runs behind compression & puts necessary whitespaces in calcs.
More info about calc issue u can find [here](https://github.com/yui/yuicompressor/issues/254).