### PR TITLE
Gradle 6.0 compatibility by removing deprecated API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id "com.gradle.plugin-publish" version "0.9.4"
-    id "com.jfrog.bintray" version "1.6"
+    id "com.gradle.plugin-publish" version "0.10.1"
+    id "com.jfrog.bintray" version "1.8.4"
 }
 
 apply plugin: 'groovy'
@@ -10,8 +10,8 @@ apply plugin: 'signing'
 apply plugin: 'idea'
 apply plugin: 'jacoco'
 
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
 
 defaultTasks 'clean', 'build'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.3.1-bin.zip

--- a/src/main/groovy/com/eriwen/gradle/css/source/internal/DefaultCssSourceSetContainer.java
+++ b/src/main/groovy/com/eriwen/gradle/css/source/internal/DefaultCssSourceSetContainer.java
@@ -4,6 +4,7 @@ import com.eriwen.gradle.css.source.CssSourceSet;
 import com.eriwen.gradle.css.source.CssSourceSetContainer;
 import org.gradle.api.Project;
 import org.gradle.api.internal.AbstractNamedDomainObjectContainer;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.internal.reflect.Instantiator;
 
@@ -14,7 +15,7 @@ public class DefaultCssSourceSetContainer extends AbstractNamedDomainObjectConta
     private final FileResolver fileResolver;
 
     public DefaultCssSourceSetContainer(Project project, Instantiator instantiator, FileResolver fileResolver) {
-        super(CssSourceSet.class, instantiator);
+        super(CssSourceSet.class, instantiator, CollectionCallbackActionDecorator.NOOP);
         this.project = project;
         this.instantiator = instantiator;
         this.fileResolver = fileResolver;


### PR DESCRIPTION
Fixes gradle-js-plugin issue [#168](https://github.com/eriwen/gradle-js-plugin/issues/168) which also exists in this project.